### PR TITLE
Add brew as alternative for installing llvm on Linux

### DIFF
--- a/getting-started/cpp-stuff.md
+++ b/getting-started/cpp-stuff.md
@@ -72,6 +72,12 @@ On Arch-based systems:
 pacman -S clang lld llvm
 ```
 
+Alternatively, you can use [brew](https://brew.sh/) (Linuxbrew) on Linux just like on macOS:
+
+```bash
+brew install llvm
+```
+
 The next step will install the Windows SDK and a CMake toolchain. For ease of installation, first install [the Geode CLI](/getting-started/geode-cli.md) and then come back here. If you want to do it manually, you can follow [this guide](https://gist.github.com/matcool/abb65ee59ded3766717c673014c3a2a7).
 
 After installing the CLI, run this command to install all the needed tools:


### PR DESCRIPTION
Fixes #48

This PR adds documentation noting that Linux users can use Homebrew (Linuxbrew) as an alternative way to install LLVM, just like macOS users.

Changes:
- Added a note in the Linux section of cpp-stuff.md mentioning brew as an alternative to apt/dnf/pacman