### PR TITLE
Documentation improvements: namespaces, moderation timeline, VS toolset

### DIFF
--- a/getting-started/ide-setup.md
+++ b/getting-started/ide-setup.md
@@ -134,7 +134,7 @@ Now, before you build, make sure to change these settings (these need to be chan
 ![Image showing the Manage Configurations button in the drop-down](/assets/vs_manage_configurations.png)
 
 3. Change config type to `Release` or `RelWithDebInfo`. We recommend `RelWithDebInfo`, since it provides easier debugging. **You cannot use `Debug` for this!**
-4. Make sure the toolset is set to `x64`
+4. Make sure the toolset is set to `x64` (NOT `x64_x86` or any other variant)
 5. At this point you can also give your configuration a friendly name such as "default" or "release" or something like that
 6. And make sure to use Ctrl + S to save your changes
 

--- a/mods/publishing.md
+++ b/mods/publishing.md
@@ -15,6 +15,7 @@ Submitting a mod to the official mod index is as follows:
 5. Run `geode index mods create`
 6. Provide a **direct download link** to the .geode file (for example `https://github.com/HJfod/BetterEdit/releases/download/v6.3.3/hjfod.betteredit.geode`)
 7. An **index admin** will have to validate that your mod meets the [index guidelines](/mods/guidelines) and approve your mod.
+8. **Approval typically takes 1-7 days.** Please be patient - the team is reviewing mods as quickly as possible while ensuring quality and safety.
 
 ## Releasing updates
 

--- a/source/namespaces.md
+++ b/source/namespaces.md
@@ -1,0 +1,140 @@
+# Geode Namespaces
+
+This document describes the purpose of each namespace in the Geode SDK.
+
+## Main Namespaces
+
+### `geode`
+The root namespace for all Geode functionality. Contains core classes and functions for mod development.
+
+**Key classes:**
+- `Loader` - Main entry point for interacting with Geode
+- `Mod` - Represents a mod and its metadata
+- `ModMetadata` - Information about a mod
+- `Event`/`EventFilter` - Event system for mod communication
+
+---
+
+### `geode::modifier`
+Contains utilities for modifying Geometry Dash classes and functions.
+
+**Key classes:**
+- `Modify` - Base class for creating hooks
+- `Field` - For adding fields to existing classes
+- `AsStaticFunction` - Converts member functions to static
+
+**Usage:**
+```cpp
+using namespace geode::modifier;
+
+class $modify(MyMenuLayer, MenuLayer) {
+    // Your modifications here
+};
+```
+
+---
+
+### `geode::addresser`
+Utilities for memory address manipulation and function resolution.
+
+**Key functions:**
+- `getNonVirtual` - Get address of non-virtual functions
+- `getVirtual` - Get address of virtual functions
+- `getThisAdjustment` - Get `this` pointer adjustments
+
+---
+
+### `geode::async`
+Asynchronous programming utilities including coroutines and promises.
+
+**Key classes:**
+- `Promise<T>` - Represents a future value
+- `Task<T>` - An async operation that can be started/cancelled
+- `Coro` - Coroutine helper for async/await style code
+
+**Usage:**
+```cpp
+geode::async::Task<std::string> fetchData() {
+    auto result = co_await web::fetch("https://api.example.com");
+    co_return result.string().unwrap();
+}
+```
+
+---
+
+### `geode::cocos`
+Utilities for working with cocos2d-x (the game engine).
+
+**Key classes:**
+- `CCNodeRef` - Smart pointer for CCNode
+- Various helper functions for node manipulation
+
+---
+
+### `geode::stl`
+Standard library extensions and custom containers.
+
+**Key classes:**
+- `fixed_string` - String with compile-time size
+- Custom STL allocators for Geode
+
+---
+
+### `geode::utils`
+General utility functions.
+
+**Sub-namespaces:**
+- `geode::utils::file` - File operations
+- `geode::utils::string` - String manipulation
+- `geode::utils::web` - Web requests
+- `geode::utils::cocos` - Cocos2d helper functions
+
+---
+
+## Platform Namespaces
+
+### `geode::base`
+Platform-specific base implementations. Usually not used directly.
+
+### `geode::platform`
+Platform detection and platform-specific code.
+
+---
+
+## Internal Namespaces
+
+These namespaces are used internally by Geode and should generally not be used by mod developers:
+
+- `geode::internal` - Internal implementation details
+- `geode::geode_internal` - Core internal functions
+- `geode::cast` - Internal casting utilities
+
+---
+
+## External Namespaces
+
+### `gd`
+Shortcut namespace for Geometry Dash classes. Contains bindings to GD classes.
+
+**Usage:**
+```cpp
+// These are equivalent:
+MenuLayer* layer;
+gd::MenuLayer* layer;  // Shortcut
+```
+
+### `cocos2d`
+The cocos2d-x game engine namespace. Contains all cocos2d classes like:
+- `CCNode`, `CCLayer`, `CCScene` - Node hierarchy
+- `CCSprite` - Images and textures
+- `CCMenu`, `CCMenuItem` - UI elements
+- `CCDirector` - Game management
+
+---
+
+## Best Practices
+
+1. **Use `using namespace geode;`** in your `.cpp` files for convenience
+2. **Use `using namespace geode::prelude;`** for the most common includes
+3. **Don't use internal namespaces** - they're subject to change
+4. **Prefer `gd::` shortcut** for GD class names


### PR DESCRIPTION
This PR contains multiple documentation improvements:

## 1. Namespace Documentation (#911)

Created comprehensive `source/namespaces.md` documenting:
- `geode` - Root namespace
- `geode::modifier` - Hooking utilities
- `geode::addresser` - Memory manipulation
- `geode::async` - Coroutines
- `geode::utils` - Utilities
- `gd` - Geometry Dash shortcut
- `cocos2d` - Game engine
- Best practices

## 2. Moderation Timeline (#68)

Added note about typical mod approval time (1-7 days) to publishing page.

## 3. VS Toolset Clarification (#72)

Added explicit note to use x64 toolset (NOT x64_x86) in IDE setup.

---

Closes #68
Closes #72
Closes #911